### PR TITLE
MainActivity: longer timeouts for daemons startup

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/MainActivity.kt
@@ -449,7 +449,7 @@ class MainActivity : UriResultActivity() {
                     return true
             } catch (err: Exception) {
             }
-            Thread.sleep(2000)
+            Thread.sleep(5000)
         }
         return false
     }
@@ -462,7 +462,7 @@ class MainActivity : UriResultActivity() {
             } catch (err: Exception) {
                 Log.d(TAG, err.localizedMessage)
             }
-            Thread.sleep(2000)
+            Thread.sleep(5000)
         }
         return false
     }


### PR DESCRIPTION
My application would always timeout and never starts. I went for the simplest patch possible but the mechanism itself isn't very robust imho.