### PR TITLE
Redirect URL ndk to a fork for the moment

### DIFF
--- a/app/src/main/java/com/lvaccaro/lamp/utils/Archive.kt
+++ b/app/src/main/java/com/lvaccaro/lamp/utils/Archive.kt
@@ -10,7 +10,7 @@ import java.io.*
 class Archive {
 
     companion object {
-        const val RELEASE = "v0.9.3"
+        const val RELEASE = "v0.10.0_miami"
 
         fun arch(): String {
             var abi: String?
@@ -36,7 +36,8 @@ class Archive {
 
         fun url(): String {
             val TAR_FILENAME = tarFilename()
-            return "https://github.com/lightningamp/lightning_ndk/releases/download/${RELEASE}/${TAR_FILENAME}"
+            //return "https://github.com/lightningamp/lightning_ndk/releases/download/${RELEASE}/${TAR_FILENAME}"
+            return "https://github.com/vincenzopalazzo/lightning_ndk/releases/download/${RELEASE}/${TAR_FILENAME}"
         }
 
         fun delete(downloadDir: File): Boolean {

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,6 @@ allprojects {
     repositories {
         google()
         jcenter()
-        
     }
 }
 


### PR DESCRIPTION
[With the consensus](https://github.com/lightningamp/lamp/issues/98#issuecomment-853107271) of @lvaccaro I update the version of ndk to the 0.10.0 of lightning

Now @darosior you have your fix with the new ndk on the master

Fixes #98